### PR TITLE
Update demo to use fidesctl 1.2.0 and fidesops 1.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help install server test fidesctl-init-db fidesctl-evaluate fidesops-request fidesops-test compose-up teardown clean black
+.PHONY: help install server test fidesctl-evaluate fidesops-request fidesops-test compose-up teardown clean black
 
 help:
 	@echo --------------------
@@ -10,8 +10,6 @@ help:
 	@echo server - Runs the Flask server in development mode, including using compose-up to start all dependencies
 	@echo ----
 	@echo test - Runs the pytest suite, including using compose-up to start all dependencies
-	@echo ----
-	@echo fidesctl-init-db - Initializes fidesctl database
 	@echo ----
 	@echo fidesctl-evaluate - Uses fidesctl to perform a dry policy evaluation of the project manifests in fides_resources/
 	@echo ----
@@ -42,8 +40,6 @@ install: compose-up
 	@./venv/bin/pip install -e .
 	@echo "Initializing Flask database..."
 	FLASK_APP=flaskr FLASK_ENV=development ./venv/bin/flask init-db
-	@echo "Initializing fidesctl db.."
-	./venv/bin/fidesctl init-db
 	@echo "Done! Run '. venv/bin/activate' to activate venv"
 
 server: compose-up
@@ -57,10 +53,6 @@ test: compose-up
 ####################
 # fidesctl
 ####################
-
-fidesctl-init-db: compose-up
-	@echo "Initializing fidesctl db.."
-	./venv/bin/fidesctl init-db
 
 fidesctl-evaluate: compose-up
 	@echo "Evaluating policy with fidesctl..."
@@ -96,7 +88,6 @@ reset-db: teardown
 	docker volume rm fidesdemo_postgres
 	@make compose-up
 	FLASK_APP=flaskr FLASK_ENV=development ./venv/bin/flask init-db
-	./venv/bin/fidesctl init-db
 
 clean: teardown
 	@echo "Cleaning project files, docker containers, volumes, etc...."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - POSTGRES_MULTIPLE_DATABASES=flaskr,fidesctl,fidesops
 
   fidesctl:
-    image: ethyca/fidesctl:1.0.0
+    image: ethyca/fidesctl:1.2.0
     depends_on:
       - db
     command: fidesctl webserver
@@ -35,7 +35,7 @@ services:
       - "6379:6379"
 
   fidesops:
-    image: ethyca/fidesops:1.0.0
+    image: ethyca/fidesops:1.1.0
     depends_on:
       - db
       - redis

--- a/fides_resources/flaskr_policy.yml
+++ b/fides_resources/flaskr_policy.yml
@@ -7,12 +7,12 @@ policy:
         name: Minimize User Identifiable Data
         description: Reject collecting any user identifiable data for uses other than system operations
         data_categories:
-          inclusion: ANY
+          matches: ANY
           values:
             - user.provided.identifiable
             - user.derived.identifiable
         data_uses:
-          inclusion: ANY
+          matches: ANY
           values:
             - improve
             - personalize
@@ -21,7 +21,7 @@ policy:
             - collect
             - train_ai_system
         data_subjects:
-          inclusion: ANY
+          matches: ANY
           values:
             - customer
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
@@ -31,7 +31,7 @@ policy:
         name: Reject Sensitive Data
         description: Reject collecting sensitive user data for any use
         data_categories:
-          inclusion: ANY
+          matches: ANY
           values:
             - user.provided.identifiable.biometric
             - user.provided.identifiable.childrens
@@ -42,7 +42,7 @@ policy:
             - user.provided.identifiable.religious_belief
             - user.provided.identifiable.sexual_orientation
         data_uses:
-          inclusion: ANY
+          matches: ANY
           values:
             - provide
             - improve
@@ -52,7 +52,7 @@ policy:
             - collect
             - train_ai_system
         data_subjects:
-          inclusion: ANY
+          matches: ANY
           values:
             - customer
         data_qualifier: aggregated

--- a/fides_resources/flaskr_postgres_dataset.yml
+++ b/fides_resources/flaskr_postgres_dataset.yml
@@ -9,12 +9,21 @@ dataset:
       data_categories: [system.operations]
     - name: description
       data_categories: [user.provided.identifiable]
+      fidesops_meta:
+        data_type: string
     - name: id
       data_categories: [system.operations]
+      fidesops_meta:
+        primary_key: True
+        data_type: integer
     - name: name
       data_categories: [user.provided.identifiable]
+      fidesops_meta:
+        data_type: string
     - name: price
       data_categories: [user.provided.identifiable]
+      fidesops_meta:
+        data_type: integer
     - name: seller_id
       data_categories: [user.derived.identifiable.unique_id]
       fidesops_meta:
@@ -22,6 +31,7 @@ dataset:
           - dataset: flaskr_postgres_dataset
             field: users.id
             direction: from
+        data_type: integer
   - name: purchases
     fields:
     - name: buyer_id
@@ -31,22 +41,38 @@ dataset:
           - dataset: flaskr_postgres_dataset
             field: users.id
             direction: from
+        data_type: integer
     - name: city
       data_categories: [user.provided.identifiable.contact.city]
+      fidesops_meta:
+        data_type: string
     - name: created_at
       data_categories: [system.operations]
     - name: id
       data_categories: [system.operations]
+      fidesops_meta:
+        primary_key: True
+        data_type: integer
     - name: product_id
       data_categories: [system.operations]
+      fidesops_meta:
+        data_type: integer
     - name: state
       data_categories: [user.provided.identifiable.contact.state]
+      fidesops_meta:
+        data_type: string
     - name: street_1
       data_categories: [user.provided.identifiable.contact.street]
+      fidesops_meta:
+        data_type: string
     - name: street_2
       data_categories: [user.provided.identifiable.contact.street]
+      fidesops_meta:
+        data_type: string
     - name: zip
       data_categories: [user.provided.identifiable.contact.postal_code]
+      fidesops_meta:
+        data_type: string
   - name: users
     fields:
     - name: created_at
@@ -55,12 +81,22 @@ dataset:
       data_categories: [user.provided.identifiable.contact.email]
       fidesops_meta:
         identity: email
+        data_type: string
     - name: first_name
       data_categories: [user.provided.identifiable.name]
+      fidesops_meta:
+        data_type: string
     - name: id
       data_categories: [user.derived.identifiable.unique_id]
+      fidesops_meta:
+        primary_key: True
+        data_type: integer
     - name: last_name
       data_categories: [user.provided.identifiable.name]
+      fidesops_meta:
+        data_type: string
     - name: password
       data_categories: [user.provided.identifiable.credentials.password]
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized
+      fidesops_meta:
+        data_type: string

--- a/flaskr/fidesops.py
+++ b/flaskr/fidesops.py
@@ -116,7 +116,7 @@ def create_postgres_connection(key, access_token):
             "access": "write",
         },
     ]
-    response = requests.put(
+    response = requests.patch(
         f"{FIDESOPS_URL}/api/v1/connection",
         headers=oauth_headers(access_token=access_token),
         json=connection_create_data,
@@ -205,7 +205,7 @@ def validate_dataset(connection_key, yaml_path, access_token):
             )
 
     raise RuntimeError(
-        f"fidesops dataset creation failed! response.status_code={response.status_code}, response.json()={response.json()}"
+        f"fidesops dataset validation failed! response.status_code={response.status_code}, response.json()={response.json()}"
     )
 
 
@@ -225,7 +225,7 @@ def create_dataset(connection_key, yaml_path, access_token):
         dataset = yaml.safe_load(file).get("dataset", [])[0]
 
     dataset_create_data = [dataset]
-    response = requests.put(
+    response = requests.patch(
         f"{FIDESOPS_URL}/api/v1/connection/{connection_key}/dataset",
         headers=oauth_headers(access_token=access_token),
         json=dataset_create_data,
@@ -263,7 +263,7 @@ def create_local_storage(key, format, access_token):
             },
         },
     ]
-    response = requests.put(
+    response = requests.patch(
         f"{FIDESOPS_URL}/api/v1/storage/config",
         headers=oauth_headers(access_token=access_token),
         json=storage_create_data,
@@ -297,7 +297,7 @@ def create_policy(key, access_token):
             "key": key,
         },
     ]
-    response = requests.put(
+    response = requests.patch(
         f"{FIDESOPS_URL}/api/v1/policy",
         headers=oauth_headers(access_token=access_token),
         json=policy_create_data,
@@ -329,10 +329,11 @@ def delete_policy_rule(policy_key, key, access_token):
 
 
 def create_policy_rule(
-    policy_key, key, action_type, storage_destination_key, access_token
+    policy_key, key, action_type, storage_destination_key, masking_strategy, access_token
 ):
     """
-    Create a policy rule to return matched data in an access request to the given storage destination.
+    Create a policy rule to either access data and upload to a storage
+    destination, or erase data with the given masking strategy.
 
     Returns the response JSON if successful, or throws an error otherwise.
 
@@ -345,9 +346,10 @@ def create_policy_rule(
             "key": key,
             "action_type": action_type,
             "storage_destination_key": storage_destination_key,
+            "masking_strategy": masking_strategy,
         },
     ]
-    response = requests.put(
+    response = requests.patch(
         f"{FIDESOPS_URL}/api/v1/policy/{policy_key}/rule",
         headers=oauth_headers(access_token=access_token),
         json=rule_create_data,
@@ -380,7 +382,7 @@ def create_policy_rule_target(policy_key, rule_key, data_category, access_token)
             "data_category": data_category,
         },
     ]
-    response = requests.put(
+    response = requests.patch(
         f"{FIDESOPS_URL}/api/v1/policy/{policy_key}/rule/{rule_key}/target",
         headers=oauth_headers(access_token=access_token),
         json=target_create_data,
@@ -433,24 +435,31 @@ def create_privacy_request(email, policy_key, access_token):
         f"fidesops privacy request creation failed! response.status_code={response.status_code}, response.json()={response.json()}"
     )
 
-
 def print_results(privacy_request_id):
     """
     Check to see if a result JSON for the given privacy request exists, and
     print it to the console if so.
     """
     results_path = f"fides_uploads/{privacy_request_id}.json"
-    if exists(results_path):
-        logger.info(
-            f"Successfully read fidesops privacy request results from {results_path}:"
-        )
-        with open(f"fides_uploads/{privacy_request_id}.json", "r") as file:
-            results_json = json.loads(file.read())
-            print(json.dumps(results_json, indent=4))
-    else:
-        raise RuntimeError(
-            f"fidesops privacy request results not found at results_path={results_path}"
-        )
+    wait_time = 0
+    print(f"Waiting for fidesops privacy request results to upload to {results_path}...")
+    while wait_time < 5:
+        if exists(results_path):
+            requests.get(f"{FIDESOPS_URL}/health")
+            logger.info(
+                f"Successfully read fidesops privacy request results from {results_path}:"
+            )
+            with open(f"fides_uploads/{privacy_request_id}.json", "r") as file:
+                results_json = json.loads(file.read())
+                print(json.dumps(results_json, indent=4))
+            return
+        else:
+            time.sleep(0.1)
+            wait_time += 0.1
+
+    raise RuntimeError(
+        f"fidesops privacy requests failed to upload to {results_path}!"
+    )
 
 
 if __name__ == "__main__":
@@ -564,23 +573,35 @@ if __name__ == "__main__":
             key="example_request_policy",
             access_token=access_token,
         )
+
+        # Choose the action type
+        print(
+            "\n\nSelect the action type for request policy (access or erasure) [access]"
+        )
+        action_type = input() or "access"
+        masking_strategy = {
+            "strategy": "null_rewrite",
+            "configuration": {}
+        }
+
         # Delete any existing policy rule so we can reconfigure it based on input
         delete_policy_rule(
             policy_key="example_request_policy",
-            key="access_user_data",
+            key="example_policy_rule",
             access_token=access_token,
         )
         create_policy_rule(
             policy_key="example_request_policy",
-            key="access_user_data",
-            action_type="access",
+            key="example_policy_rule",
+            action_type=action_type,
             storage_destination_key="example_storage",
+            masking_strategy=masking_strategy,
             access_token=access_token,
         )
         for data_category in data_categories:
             create_policy_rule_target(
                 policy_key="example_request_policy",
-                rule_key="access_user_data",
+                rule_key="example_policy_rule",
                 data_category=data_category,
                 access_token=access_token,
             )
@@ -596,7 +617,8 @@ if __name__ == "__main__":
             access_token=access_token,
         )
         privacy_request_id = privacy_requests["succeeded"][0]["id"]
-        print_results(privacy_request_id=privacy_request_id)
+        if action_type == "access":
+            print_results(privacy_request_id=privacy_request_id)
 
         print("Complete! Press [y] to execute another request (or any key to quit)")
         should_continue = input() == "y"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black>=21.9b0
 click>=7.0.0
-fidesctl==1.0.0
+fidesctl==1.2.0
 Flask>=1.1.4
 Flask-SQLAlchemy>=2.5.1
 psycopg2>=2.9.1


### PR DESCRIPTION
This updates the demo to use fidesctl:1.2.0 and fidesops:1.1.0, with a few API changes and the addition of the ability to run erasures from the `make fidesops-request` target.

This is currently blocked by https://github.com/ethyca/fides/issues/318.