### PR TITLE
Update demo to use fidesctl 1.2.0 & fidesops 1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help install server test fidesctl-init-db fidesctl-evaluate fidesops-request fidesops-test compose-up teardown clean black
+.PHONY: help install server test fidesctl-evaluate fidesops-request fidesops-test compose-up teardown clean black
 
 help:
 	@echo --------------------
@@ -10,8 +10,6 @@ help:
 	@echo server - Runs the Flask server in development mode, including using compose-up to start all dependencies
 	@echo ----
 	@echo test - Runs the pytest suite, including using compose-up to start all dependencies
-	@echo ----
-	@echo fidesctl-init-db - Initializes fidesctl database
 	@echo ----
 	@echo fidesctl-evaluate - Uses fidesctl to perform a dry policy evaluation of the project manifests in fides_resources/
 	@echo ----
@@ -42,8 +40,6 @@ install: compose-up
 	@./venv/bin/pip install -e .
 	@echo "Initializing Flask database..."
 	FLASK_APP=flaskr FLASK_ENV=development ./venv/bin/flask init-db
-	@echo "Initializing fidesctl db.."
-	./venv/bin/fidesctl init-db
 	@echo "Done! Run '. venv/bin/activate' to activate venv"
 
 server: compose-up
@@ -57,10 +53,6 @@ test: compose-up
 ####################
 # fidesctl
 ####################
-
-fidesctl-init-db: compose-up
-	@echo "Initializing fidesctl db.."
-	./venv/bin/fidesctl init-db
 
 fidesctl-evaluate: compose-up
 	@echo "Evaluating policy with fidesctl..."
@@ -96,13 +88,12 @@ reset-db: teardown
 	docker volume rm fidesdemo_postgres
 	@make compose-up
 	FLASK_APP=flaskr FLASK_ENV=development ./venv/bin/flask init-db
-	./venv/bin/fidesctl init-db
 
 clean: teardown
 	@echo "Cleaning project files, docker containers, volumes, etc...."
 	docker system prune -a --volumes
 	rm -rf instance/ venv/ __pycache__/
-	rm fides_uploads/*.json
+	rm -f fides_uploads/*.json
 
 black:
 	@echo "Auto-formatting project code with Black..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - POSTGRES_MULTIPLE_DATABASES=flaskr,fidesctl,fidesops
 
   fidesctl:
-    image: ethyca/fidesctl:1.0.0
+    image: ethyca/fidesctl:1.2.0
     depends_on:
       - db
     command: fidesctl webserver
@@ -35,7 +35,7 @@ services:
       - "6379:6379"
 
   fidesops:
-    image: ethyca/fidesops:1.0.0
+    image: ethyca/fidesops:1.2.0
     depends_on:
       - db
       - redis

--- a/fides_resources/flaskr_policy.yml
+++ b/fides_resources/flaskr_policy.yml
@@ -7,12 +7,12 @@ policy:
         name: Minimize User Identifiable Data
         description: Reject collecting any user identifiable data for uses other than system operations
         data_categories:
-          inclusion: ANY
+          matches: ANY
           values:
             - user.provided.identifiable
             - user.derived.identifiable
         data_uses:
-          inclusion: ANY
+          matches: ANY
           values:
             - improve
             - personalize
@@ -21,7 +21,7 @@ policy:
             - collect
             - train_ai_system
         data_subjects:
-          inclusion: ANY
+          matches: ANY
           values:
             - customer
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
@@ -31,7 +31,7 @@ policy:
         name: Reject Sensitive Data
         description: Reject collecting sensitive user data for any use
         data_categories:
-          inclusion: ANY
+          matches: ANY
           values:
             - user.provided.identifiable.biometric
             - user.provided.identifiable.childrens
@@ -42,7 +42,7 @@ policy:
             - user.provided.identifiable.religious_belief
             - user.provided.identifiable.sexual_orientation
         data_uses:
-          inclusion: ANY
+          matches: ANY
           values:
             - provide
             - improve
@@ -52,7 +52,7 @@ policy:
             - collect
             - train_ai_system
         data_subjects:
-          inclusion: ANY
+          matches: ANY
           values:
             - customer
         data_qualifier: aggregated

--- a/fides_resources/flaskr_postgres_dataset.yml
+++ b/fides_resources/flaskr_postgres_dataset.yml
@@ -9,12 +9,21 @@ dataset:
       data_categories: [system.operations]
     - name: description
       data_categories: [user.provided.identifiable]
+      fidesops_meta:
+        data_type: string
     - name: id
       data_categories: [system.operations]
+      fidesops_meta:
+        primary_key: True
+        data_type: integer
     - name: name
       data_categories: [user.provided.identifiable]
+      fidesops_meta:
+        data_type: string
     - name: price
       data_categories: [user.provided.identifiable]
+      fidesops_meta:
+        data_type: integer
     - name: seller_id
       data_categories: [user.derived.identifiable.unique_id]
       fidesops_meta:
@@ -22,6 +31,7 @@ dataset:
           - dataset: flaskr_postgres_dataset
             field: users.id
             direction: from
+        data_type: integer
   - name: purchases
     fields:
     - name: buyer_id
@@ -31,22 +41,38 @@ dataset:
           - dataset: flaskr_postgres_dataset
             field: users.id
             direction: from
+        data_type: integer
     - name: city
       data_categories: [user.provided.identifiable.contact.city]
+      fidesops_meta:
+        data_type: string
     - name: created_at
       data_categories: [system.operations]
     - name: id
       data_categories: [system.operations]
+      fidesops_meta:
+        primary_key: True
+        data_type: integer
     - name: product_id
       data_categories: [system.operations]
+      fidesops_meta:
+        data_type: integer
     - name: state
       data_categories: [user.provided.identifiable.contact.state]
+      fidesops_meta:
+        data_type: string
     - name: street_1
       data_categories: [user.provided.identifiable.contact.street]
+      fidesops_meta:
+        data_type: string
     - name: street_2
       data_categories: [user.provided.identifiable.contact.street]
+      fidesops_meta:
+        data_type: string
     - name: zip
       data_categories: [user.provided.identifiable.contact.postal_code]
+      fidesops_meta:
+        data_type: string
   - name: users
     fields:
     - name: created_at
@@ -55,12 +81,22 @@ dataset:
       data_categories: [user.provided.identifiable.contact.email]
       fidesops_meta:
         identity: email
+        data_type: string
     - name: first_name
       data_categories: [user.provided.identifiable.name]
+      fidesops_meta:
+        data_type: string
     - name: id
       data_categories: [user.derived.identifiable.unique_id]
+      fidesops_meta:
+        primary_key: True
+        data_type: integer
     - name: last_name
       data_categories: [user.provided.identifiable.name]
+      fidesops_meta:
+        data_type: string
     - name: password
       data_categories: [user.provided.identifiable.credentials.password]
       data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized
+      fidesops_meta:
+        data_type: string

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black>=21.9b0
 click>=7.0.0
-fidesctl==1.0.0
+fidesctl==1.2.0
 Flask>=1.1.4
 Flask-SQLAlchemy>=2.5.1
 psycopg2>=2.9.1


### PR DESCRIPTION
This updates the demo to use fidesctl:1.2.0 and fidesops:1.2.0, with a few API changes and the addition of the ability to run erasures from the make fidesops-request target.