### PR TITLE
Update /auth template and logic to display and propagate `last_name` correctly

### DIFF
--- a/flaskr/auth.py
+++ b/flaskr/auth.py
@@ -25,7 +25,7 @@ def register():
         email = request.form["email"]
         password = request.form["password"]
         first_name = request.form["first_name"]
-        last_name = request.form["first_name"]
+        last_name = request.form["last_name"]
         db = get_db()
         error = None
 

--- a/flaskr/templates/auth/register.html
+++ b/flaskr/templates/auth/register.html
@@ -12,7 +12,7 @@
     <input class="form-control" type="password" name="password" id="password" required>
     <label class="form-label" for="first_name">First Name</label class="form-label">
     <input class="form-control" type="text" name="first_name" id="first_name" required>
-    <label class="form-label" for="last_name">First Name</label class="form-label">
+    <label class="form-label" for="last_name">Last Name</label class="form-label">
     <input class="form-control" type="text" name="last_name" id="last_name" required>
     <input class="btn btn-primary" type="submit" value="Register">
   </form>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -30,6 +30,8 @@ def test_register(client, app):
     (
         ("", "", "a", "a", b"Email is required."),
         ("a", "", "a", "a", b"Password is required."),
+        ("a", "a", "", "a", b"First Name is required."),
+        ("a", "a", "a", "", b"Last Name is required."),
         ("admin@example.com", "admin", "a", "a", b"already registered"),
     ),
 )


### PR DESCRIPTION
I noticed that the registration template displayed the "First Name" string twice, for which one of the input fields was labeled as `last_name`. However, the `last_name` field wasn't being read by the server.

This PR:
- updates the /auth template page to display "Last Name"
- propagates the `last_name` field value into the registration demo
- adds test variants for first and last names that catch this, since they're both required in the demo

However: I note that this PR wouldn't magically update all of the tags/stages of the tutorial that have this teeny bug, and don't have a suggestion on whether or not this is worth worrying about. :-) 