### PR TITLE
Replace aggressive docker prune in `make clean` with suggestion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,10 @@ reset-db: teardown
 	FLASK_APP=flaskr FLASK_ENV=development ./venv/bin/flask init-db
 
 clean: teardown
-	@echo "Cleaning project files, docker containers, volumes, etc...."
-	docker system prune -a --volumes
+	@echo "Cleaning project files, venv, pycache..."
 	rm -rf instance/ venv/ __pycache__/
 	rm -f fides_uploads/*.json
+	@echo "To remove all docker artifacts, consider: 'docker prune --help'"
 
 black:
 	@echo "Auto-formatting project code with Black..."


### PR DESCRIPTION
per ethyca/fidesdemo/#13

This PR removes the aggressive `docker prune` invocation from `make clean`, and instead leaves a note suggesting that users interested in pruning docker resources perform it themselves.

Note: The `make teardown` invocation will still remove the volume created by this demo, so users would only be seeking to prune images. Non-demo volume data is now out of scope of the demo completely.