### PR TITLE
Improve Windows Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,8 @@ demo: preinstall
 	@echo "Fidesops Privacy Center running at http://localhost:4000"
 	@echo "Fidesops Admin UI running at http://localhost:3000/login (user: fidesopsuser, pass: fidesops1A!)"
 	@echo "Example eCommerce demo app running at http://localhost:2000 (user: user@example.com, pass: user)"
+	@open demo.html
 	@echo ""
-	@echo "Opening in browser in 5 seconds..."
-	@sleep 5 && open demo.html &
 	@FLASK_APP=flaskr FLASK_ENV=development FLASK_RUN_PORT=2000 FLASK_SKIP_DOTENV=true ./venv/bin/flask run
 
 

--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,10 @@ help:
 
 .PHONY: preinstall
 preinstall:
-	@echo "Checking versions of fidesdemo dependencies:"
+	@echo "Checking versions of fidesdemo dependencies. Minimum requirements: Python 3.7, Docker 20.10.11"
 	@python3 --version
-	@python3 -m platform
 	@docker --version
-	@docker-compose --version
-	@pg_config --version
+	@python3 -m platform
 
 .PHONY: install
 install: preinstall compose-up
@@ -215,15 +213,14 @@ fidesops-watch:
 .PHONY: compose-up
 compose-up:
 	@echo "Rebuilding docker images as needed..."
-	@docker-compose build
+	@docker compose build
 	@echo "Bringing up docker containers..."
-	@docker-compose up -d
-	@pg_isready --host localhost --port 6432 || (echo "Waiting 5s for Postgres to start..." && sleep 5)
+	@docker compose up -d
 
 .PHONY: teardown
 teardown:
 	@echo "Bringing down docker containers..."
-	@docker-compose down --remove-orphans
+	@docker compose down --remove-orphans
 
 .PHONY: reset-db
 reset-db: teardown
@@ -238,7 +235,7 @@ reset-db: teardown
 clean: teardown
 	@echo ""
 	@echo "Cleaning project files, docker containers, volumes, etc...."
-	docker-compose down --remove-orphans --volumes --rmi all
+	docker compose down --remove-orphans --volumes --rmi all
 	docker system prune --force
 	rm -rf instance/ venv/ __pycache__/
 	rm -f fides_tmp/*.json

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ This demo project is currently only supported on Mac OS, as the Makefile uses sh
 
 To run this project, first ensure you have the following requirements installed and running on your machine:
 
-* Docker 12+
-* Python 3.7+
+* Docker 20.10.11
+* Python 3.7
 * Make
-* `pg_config` (on Mac, install via `brew install libpq` or `brew install postgres`)
+
+Run `make preinstall` to check the installed versions of these dependencies before getting started.
 
 ## Getting Started
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,11 @@ version: "3.0"
 services:
   db:
     image: postgres:12
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
     volumes:
       - postgres:/var/lib/postgresql/data
       - ./postgres_scripts:/docker-entrypoint-initdb.d
@@ -14,8 +19,14 @@ services:
 
   fidesctl:
     image: ethyca/fidesctl:1.6.0
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://0.0.0.0:8080/api/v1/health" ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     command: fidesctl webserver
     expose:
       - 9090
@@ -31,6 +42,11 @@ services:
   redis:
     image: "redis:6.2.5-alpine"
     command: redis-server --requirepass redispass
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
     expose:
       - 7379
     ports:
@@ -39,9 +55,16 @@ services:
   fidesops:
     build: ./fidesops
     image: ethyca/fidesops-demo
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://0.0.0.0:8080/api/v1/health" ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     volumes:
       - ./fides_tmp:/fidesops/fides_uploads
     expose:


### PR DESCRIPTION
### Overview
Many of the `make` targets leverage some handy shell techniques that only work on UNIX systems, but I'd like to get this demo project working smoothly on Windows.

### Checklist

- [X]  Remove `pg_config` dependency by using docker compose healthchecks
- [X] Remove use of `sleep` by using docker compose healthchecks
- [X] Require a more recent `docker` version to rely on Docker Compose v2 features
- [ ] Find an alternative to `open` to launch the demo site?
- [ ] Test on Windows


Closes #18 