### PR TITLE
update to version 1.8.1 of fidesctl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - POSTGRES_MULTIPLE_DATABASES=flaskr,fidesctl,fidesops
 
   fidesctl:
-    image: ethyca/fidesctl:1.6.0
+    image: ethyca/fidesctl:1.8.1
     depends_on:
       - db
     command: fidesctl webserver

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black>=21.9b0
 click>=7.0.0
-fidesctl[postgres,aws]==1.6.0
+fidesctl[aws]==1.8.1
 Flask>=1.1.4
 Flask-SQLAlchemy>=2.5.1
 psycopg2-binary==2.9.1


### PR DESCRIPTION
Closes #19

Ensures that the UI comes up and can be utilized as part of including `fidesctl==1.8.1` in both the requirements.txt and the docker compose file.

Will continue to test further before calling this ok