### PR TITLE
Removing fields with unfilterable PII from dataset

### DIFF
--- a/.fides/mailchimp_dataset.yml
+++ b/.fides/mailchimp_dataset.yml
@@ -31,12 +31,6 @@ dataset:
             data_categories: [system.operations]
           - name: list_id
             data_categories: [system.operations]
-          - name: from_email
-            data_categories: [ user.provided.identifiable.contact.email ]
-          - name: from_label
-            data_categories: [ user.provided.identifiable.contact.email ]
-          - name: subject
-            data_categories: [ user.provided.nonidentifiable ]
       - name: member
         fields:
           - name: id


### PR DESCRIPTION
Related to https://github.com/ethyca/fides/issues/1951, this change removes PII from the `conversations` collection since this collection cannot be filtered to only return data for our `identity_email`.